### PR TITLE
Improve number conversion method

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11406,8 +11406,7 @@ var Potaka = (function() {
       function convertNumber(mapObj, number){
         var numberString = (number + "").trim();
         var convertedNumber = "";
-        for (var index in numberString) {
-          var digitChar = numberString[index];
+        for (var digitChar of numberString) {
           if (digitChar === ".") {
             convertedNumber += digitChar;
             continue;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11429,7 +11429,7 @@ var Potaka = (function() {
       /* take String & return Number */
       function bnToEnNumber(number){
         var mapObj = {"০":0,"১":1,"২":2,"৩":3, "৪": 4,"৫":5,"৬":6,"৭":7, "৮": 8,"৯": 9 };
-        return +convertNumber(mapObj, number);
+        return convertNumber(mapObj, number);
       }
 
       /* Custom AST for loop(n times) */

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11404,29 +11404,31 @@ var Potaka = (function() {
       }
       /* Number conversion */
       function convertNumber(mapObj, number){
-        number = number + "";
-        for(var index= 0; index<number.length; index++){
-          if(number[index] == ".") continue;
-          if(typeof mapObj[number[index]] == "undefined")
+        var numberString = (number + "").trim();
+        var convertedNumber = "";
+        for (var index in numberString) {
+          var digitChar = numberString[index];
+          if (digitChar === ".") {
+            convertedNumber += digitChar;
+            continue;
+          }
+          var convertedDigitChar = mapObj instanceof Array ? mapObj[parseInt(digitChar)] : mapObj[digitChar];
+          if (convertedDigitChar === undefined) {
             throw new Error("NaN");
+          }
+          convertedNumber += convertedDigitChar;
         }
 
-        var re = new RegExp(Object.keys(mapObj).join("|"),"gi");
-        //var str = number;
-        number  = number.replace(re, function(matched){
-          return mapObj[matched];
-        });
-
-        return number;
+        return convertedNumber;
       }
 
-      /* take number or String & return String */
+      /* Take a english number as string/number and convert it to bangla number string representation */
       function enToBnNumber(number) {
         var mapObj = ["০","১","২","৩","৪","৫","৬","৭","৮","৯"];
         return convertNumber(mapObj, number);
       }
 
-      /* take String & return Number */
+      /* Take a bangla number as string and convert it to english number string representation */
       function bnToEnNumber(number){
         var mapObj = {"০":0,"১":1,"২":2,"৩":3, "৪": 4,"৫":5,"৬":6,"৭":7, "৮": 8,"৯": 9 };
         return convertNumber(mapObj, number);


### PR DESCRIPTION
- Get rid of unnecessary regex replace as we were kind of ending up in two for loops- one was explicit, and another implicit one was inside `regex match-replace` process. We can improve the whole conversion process by simply turning it into one single loop which also takes care of everything else.
- Takes care of inputs like `enToBnNumber('1324 ')` or `enToBnNumber(' 1324')`. Previously for leading or trailing space the code was returning unexpected `NaN` error. 
- `enToBnNumber` returns a `String`, which is used that way. `bnToEnNumber` is also expected to return a string(it's usage expects a string on which we apply `parseFloat`), not a number
